### PR TITLE
Fix copy-paste feature, split into two blocks

### DIFF
--- a/docs-ref-conceptual/install-azure-cli-apt.md
+++ b/docs-ref-conceptual/install-azure-cli-apt.md
@@ -45,10 +45,15 @@ Wenn Sie eine Distribution mit `apt` verwenden (etwa Ubuntu oder Debian), steht 
   > curl -L https://packages.microsoft.com/keys/microsoft.asc | sudo apt-key add -
   > ``` 
 
-3. Installieren Sie die Befehlszeilenschnittstelle:
+3. Installieren Sie das Basispaket:
 
    ```bash
    sudo apt-get install apt-transport-https
+   ```
+
+4. Installieren Sie die Befehlszeilenschnittstelle:
+
+   ```bash
    sudo apt-get update && sudo apt-get install azure-cli
    ```
 


### PR DESCRIPTION
I had a problem with the copy-paste button to copy each command line block into my terminal.

Step 3 has two lines of bash commands. Copying both lines with the COPY button leads to an error

```
vagrant@sealnb040:~/workspace/plossys-bundle$ sudo apt-get install apt-transport-https
Reading package lists... Done
Building dependency tree
Reading state information... Done
The following package was automatically installed and is no longer required:
  libfreetype6
Use 'sudo apt autoremove' to remove it.
The following packages will be upgraded:
  apt-transport-https
1 upgraded, 0 newly installed, 0 to remove and 129 not upgraded.
Need to get 26.1 kB of archives.
After this operation, 0 B of additional disk space will be used.
Get:1 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 apt-transport-https amd64 1.2.26 [26.1 kB]
Fetched 26.1 kB in 0s (194 kB/s)
(Reading database ... 39306 files and directories currently installed.)
Preparing to unpack .../apt-transport-https_1.2.26_amd64.deb ...
Unpacking apt-transport-https (1.2.26) over (1.2.24) ...
Setting up apt-transport-https (1.2.26) ...
vagrant@sealnb040:~/workspace/plossys-bundle$ az login
az: command not found
```

I had manually to copy the second line into my terminal again to make the installation succeed:

```
vagrant@sealnb040:~/workspace/plossys-bundle$ sudo apt-get update && sudo apt-get install azure-cli
Hit:1 http://archive.ubuntu.com/ubuntu xenial InRelease
Get:2 http://archive.ubuntu.com/ubuntu xenial-updates InRelease [109 kB]
Get:3 http://archive.ubuntu.com/ubuntu xenial-backports InRelease [107 kB]
Get:4 http://security.ubuntu.com/ubuntu xenial-security InRelease [107 kB]
Get:5 https://packages.microsoft.com/repos/azure-cli xenial InRelease [2,807 B]
Get:6 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 Packages [785 kB]
```

It's better to have to code blocks 3. and 4. to make it easier to use the COPY buttons.
